### PR TITLE
Define DESTROY function

### DIFF
--- a/lib/Getopt/Kingpin/Base.pm
+++ b/lib/Getopt/Kingpin/Base.pm
@@ -21,6 +21,9 @@ sub AUTOLOAD {
     return $self;
 }
 
+sub DESTROY {
+}
+
 sub _set_types {
     my $self = shift;
     my ($type) = @_;


### PR DESCRIPTION
For fix warning messages like below.

```
    (in cleanup) type error 'DESTROY' at /home/travis/perl5/perlbrew/perls/5.10/lib/5.10.1/Test/Builder.pm line 262.
```

https://travis-ci.org/sago35/Getopt-Kingpin/jobs/167358491
