### PR TITLE
parse($arrayref) support

### DIFF
--- a/lib/Getopt/Kingpin.pm
+++ b/lib/Getopt/Kingpin.pm
@@ -140,6 +140,11 @@ sub _parse {
     };
     my $arg_index = 0;
     my $arg_only = 0;
+    
+    if (@argv == 1 and ref($argv[0]) and ref($argv[0]) eq "ARRAY") {
+        @argv = @{ $argv[0] };
+    }
+    
     while (scalar @argv > 0) {
         my $arg = shift @argv;
         if ($arg eq "--") {
@@ -648,6 +653,13 @@ If define sub-command, parse() return Getopt::Kingpin::Command object;
     my $cmd = $kingpin->parse;
     printf "cmd : %s\n", $cmd;
     printf "cmd : %s\n", $cmd->name;
+
+You may also pass an arrayref to parse():
+
+    $kingpin->parse( \@arguments );
+
+An empty arrayref will not cause Kingpin to parse @ARGV like
+an empty array would.
 
 =head2 _parse()
 

--- a/t/25_parse.t
+++ b/t/25_parse.t
@@ -48,5 +48,38 @@ subtest 'parse() with arguments' => sub {
     is $image, "abc.jpg";
 };
 
+subtest 'parse() with arrayref arguments' => sub {
+    my @argv;
+    push @argv, qw(post --server 127.0.0.1 --image=abc.jpg);
+
+    my $kingpin = Getopt::Kingpin->new();
+    my $post = $kingpin->command("post", "post image");
+    my $server = $post->flag("server", "")->string();
+    my $image = $post->flag("image", "")->file();
+
+    my $cmd = $kingpin->parse(\@argv);
+
+    is ref $cmd, "Getopt::Kingpin::Command";
+    is $cmd, "post";
+
+    is ref $post, "Getopt::Kingpin::Command";
+    is ref $server, "Getopt::Kingpin::Flag";
+    is ref $image, "Getopt::Kingpin::Flag";
+
+    is $server, "127.0.0.1";
+    is $image, "abc.jpg";
+};
+
+subtest 'parse() with empty arrayref will ignore @ARGV' => sub {
+    local @ARGV;
+    push @ARGV, qw(post --server 127.0.0.1 --image=abc.jpg);
+
+    my $kingpin = Getopt::Kingpin->new();
+
+    my $cmd = $kingpin->parse([]);
+    
+    is ref $cmd, 'Getopt::Kingpin';
+};
+
 done_testing;
 


### PR DESCRIPTION
Because `parse(@args)` expects an array of only strings (and no references), I think `parse(\@args)` can be supported without breaking anything.

Issue #36.