### PR TITLE
Allow default to be a coderef or object overloading &{}

### DIFF
--- a/lib/Getopt/Kingpin/Flag.pm
+++ b/lib/Getopt/Kingpin/Flag.pm
@@ -35,6 +35,12 @@ sub help_str {
         $ret->[0] = sprintf "-%s", $self->short_name;
     }
 
+    my $default = $self->_default;
+    my $printable_default = defined $default;
+    if (ref $default) {
+        $printable_default = Scalar::Util::blessed($default) && overload::Method($default, q[""]);
+    }
+
     if ($self->type eq "Bool") {
         $ret->[1] = sprintf "--%s", $self->name;
     } elsif ($self->is_hash) {
@@ -48,8 +54,8 @@ sub help_str {
     } else {
         if (defined $self->_placeholder) {
             $ret->[1] = sprintf '--%s=%s', $self->name, $self->_placeholder;
-        } elsif (defined $self->_default) {
-            $ret->[1] = sprintf '--%s="%s"', $self->name, $self->_default;
+        } elsif ($printable_default) {
+            $ret->[1] = sprintf '--%s="%s"', $self->name, $default;
         } else {
             $ret->[1] = sprintf "--%s=%s", $self->name, uc $self->name;
         }

--- a/t/06_default.t
+++ b/t/06_default.t
@@ -32,6 +32,20 @@ subtest 'default (list)' => sub {
     is_deeply $xxxx->value, [];
 };
 
+subtest 'default (hash)' => sub {
+    local @ARGV;
+    push @ARGV, qw();
+
+    my $kingpin = Getopt::Kingpin->new;
+    my $name = $kingpin->flag('name', 'set name')->default({"foo"=>"a","bar"=>"b"})->string_hash();
+    my $xxxx = $kingpin->flag('xxxx', 'set xxxx')->string_hash();
+
+    $kingpin->parse;
+
+    is_deeply $name->value, {"foo"=>"a","bar"=>"b"};
+    is_deeply $xxxx->value, {};
+};
+
 subtest 'default arg' => sub {
     local @ARGV;
     push @ARGV, qw();
@@ -60,6 +74,208 @@ subtest 'default arg (list)' => sub {
     is_deeply $xxxx->value, [];
 };
 
+subtest 'default arg (hash)' => sub {
+    local @ARGV;
+    push @ARGV, qw();
+
+    my $kingpin = Getopt::Kingpin->new;
+    my $name = $kingpin->arg('name', 'set name')->default({"foo"=>"a","bar"=>"b"})->string_hash();
+    my $xxxx = $kingpin->arg('xxxx', 'set xxxx')->string_hash();
+
+    $kingpin->parse;
+
+    is_deeply $name->value, {"foo"=>"a","bar"=>"b"};
+    is_deeply $xxxx->value, {};
+};
+
+subtest 'coderef default' => sub {
+    local @ARGV;
+    push @ARGV, qw();
+
+    my $kingpin = Getopt::Kingpin->new;
+    my $name = $kingpin->flag('name', 'set name')->default(sub { "default name" })->string();
+    my $xxxx = $kingpin->flag('xxxx', 'set xxxx')->string();
+
+    $kingpin->parse;
+
+    is $name, 'default name';
+    is $xxxx, '';
+};
+
+subtest 'coderef default (list)' => sub {
+    local @ARGV;
+    push @ARGV, qw();
+
+    my $kingpin = Getopt::Kingpin->new;
+    my $name = $kingpin->flag('name', 'set name')->default(sub { ["default name", "default name 2"] })->string_list();
+    my $xxxx = $kingpin->flag('xxxx', 'set xxxx')->string_list();
+
+    $kingpin->parse;
+
+    is_deeply $name->value, ['default name', 'default name 2'];
+    is_deeply $xxxx->value, [];
+};
+
+subtest 'coderef default (hash)' => sub {
+    local @ARGV;
+    push @ARGV, qw();
+
+    my $kingpin = Getopt::Kingpin->new;
+    my $name = $kingpin->flag('name', 'set name')->default(sub {{"foo"=>"a","bar"=>"b"}})->string_hash();
+    my $xxxx = $kingpin->flag('xxxx', 'set xxxx')->string_hash();
+
+    $kingpin->parse;
+
+    is_deeply $name->value, {"foo"=>"a","bar"=>"b"};
+    is_deeply $xxxx->value, {};
+};
+
+subtest 'coderef default arg' => sub {
+    local @ARGV;
+    push @ARGV, qw();
+
+    my $kingpin = Getopt::Kingpin->new;
+    my $name = $kingpin->arg('name', 'set name')->default(sub { "default name" })->string();
+    my $xxxx = $kingpin->arg('xxxx', 'set xxxx')->string();
+
+    $kingpin->parse;
+
+    is $name, 'default name';
+    is $xxxx, '';
+};
+
+subtest 'coderef default arg (list)' => sub {
+    local @ARGV;
+    push @ARGV, qw();
+
+    my $kingpin = Getopt::Kingpin->new;
+    my $name = $kingpin->arg('name', 'set name')->default(sub { ["default name", "default name 2"] })->string_list();
+    my $xxxx = $kingpin->arg('xxxx', 'set xxxx')->string_list();
+
+    $kingpin->parse;
+
+    is_deeply $name->value, ['default name', 'default name 2'];
+    is_deeply $xxxx->value, [];
+};
+
+subtest 'coderef default arg (hash)' => sub {
+    local @ARGV;
+    push @ARGV, qw();
+
+    my $kingpin = Getopt::Kingpin->new;
+    my $name = $kingpin->arg('name', 'set name')->default(sub {{"foo"=>"a","bar"=>"b"}})->string_hash();
+    my $xxxx = $kingpin->arg('xxxx', 'set xxxx')->string_hash();
+
+    $kingpin->parse;
+
+    is_deeply $name->value, {"foo"=>"a","bar"=>"b"};
+    is_deeply $xxxx->value, {};
+};
+
+# Package for overloaded defaults
+sub ov (&) {
+    package Local::Overloaded;
+    use overload '&{}' => sub { $_[0][0] };
+    bless [ @_ ];
+}
+
+subtest 'overloaded object default' => sub {
+    local @ARGV;
+    push @ARGV, qw();
+
+    my $kingpin = Getopt::Kingpin->new;
+    my $name = $kingpin->flag('name', 'set name')->default(ov { "default name" })->string();
+    my $xxxx = $kingpin->flag('xxxx', 'set xxxx')->string();
+
+    $kingpin->parse;
+
+    is $name, 'default name';
+    is $xxxx, '';
+};
+
+subtest 'overloaded object default (list)' => sub {
+    local @ARGV;
+    push @ARGV, qw();
+
+    my $kingpin = Getopt::Kingpin->new;
+    my $name = $kingpin->flag('name', 'set name')->default(ov { ["default name", "default name 2"] })->string_list();
+    my $xxxx = $kingpin->flag('xxxx', 'set xxxx')->string_list();
+
+    $kingpin->parse;
+
+    is_deeply $name->value, ['default name', 'default name 2'];
+    is_deeply $xxxx->value, [];
+};
+
+subtest 'overloaded object default (hash)' => sub {
+    local @ARGV;
+    push @ARGV, qw();
+
+    my $kingpin = Getopt::Kingpin->new;
+    my $name = $kingpin->flag('name', 'set name')->default(ov {{"foo"=>"a","bar"=>"b"}})->string_hash();
+    my $xxxx = $kingpin->flag('xxxx', 'set xxxx')->string_hash();
+
+    $kingpin->parse;
+
+    is_deeply $name->value, {"foo"=>"a","bar"=>"b"};
+    is_deeply $xxxx->value, {};
+};
+
+subtest 'overloaded object default arg' => sub {
+    local @ARGV;
+    push @ARGV, qw();
+
+    my $kingpin = Getopt::Kingpin->new;
+    my $name = $kingpin->arg('name', 'set name')->default(ov { "default name" })->string();
+    my $xxxx = $kingpin->arg('xxxx', 'set xxxx')->string();
+
+    $kingpin->parse;
+
+    is $name, 'default name';
+    is $xxxx, '';
+};
+
+subtest 'overloaded object default arg (list)' => sub {
+    local @ARGV;
+    push @ARGV, qw();
+
+    my $kingpin = Getopt::Kingpin->new;
+    my $name = $kingpin->arg('name', 'set name')->default(ov { ["default name", "default name 2"] })->string_list();
+    my $xxxx = $kingpin->arg('xxxx', 'set xxxx')->string_list();
+
+    $kingpin->parse;
+
+    is_deeply $name->value, ['default name', 'default name 2'];
+    is_deeply $xxxx->value, [];
+};
+
+subtest 'overloaded object default arg (hash)' => sub {
+    local @ARGV;
+    push @ARGV, qw();
+
+    my $kingpin = Getopt::Kingpin->new;
+    my $name = $kingpin->arg('name', 'set name')->default(ov {{"foo"=>"a","bar"=>"b"}})->string_hash();
+    my $xxxx = $kingpin->arg('xxxx', 'set xxxx')->string_hash();
+
+    $kingpin->parse;
+
+    is_deeply $name->value, {"foo"=>"a","bar"=>"b"};
+    is_deeply $xxxx->value, {};
+};
+
+subtest 'non-overloaded object default' => sub {
+    local @ARGV;
+    push @ARGV, qw();
+
+    my $kingpin = Getopt::Kingpin->new;
+    my $name = $kingpin->arg('name', 'set name')->default(bless({'x'=>3}, 'Local::SomePackage'));
+    my $xxxx = $kingpin->arg('xxxx', 'set xxxx');
+
+    $kingpin->parse;
+
+    is_deeply $name->value, bless({'x'=>3}, 'Local::SomePackage');
+    is_deeply $xxxx->value, undef;
+};
 
 done_testing;
 

--- a/t/14_help.t
+++ b/t/14_help.t
@@ -314,6 +314,77 @@ Flags:
     is $stdout, $expected;
 };
 
+subtest 'default3' => sub {
+    local @ARGV;
+    push @ARGV, qw(--help);
+
+    my $kingpin = Getopt::Kingpin->new;
+    $kingpin->terminate(sub {return @_});
+    my $name = $kingpin->flag('name', 'Set name.')->default(sub{ "default name" })->string();
+
+    my $expected = sprintf <<'...', basename($0);
+usage: %s [<flags>]
+
+Flags:
+  --help       Show context-sensitive help.
+  --name=NAME  Set name.
+
+...
+
+    my ($stdout, $stderr, $ret, $exit) = capture {
+        $kingpin->parse;
+    };
+    is $stdout, $expected;
+};
+
+subtest 'default4' => sub {
+    { package Local::Overloaded; use overload '&{}' => sub { $_[0][0] } };
+    local @ARGV;
+    push @ARGV, qw(--help);
+
+    my $kingpin = Getopt::Kingpin->new;
+    $kingpin->terminate(sub {return @_});
+    my $name = $kingpin->flag('name', 'Set name.')->default(bless [sub{ "default name" }], 'Local::Overloaded')->string();
+
+    my $expected = sprintf <<'...', basename($0);
+usage: %s [<flags>]
+
+Flags:
+  --help       Show context-sensitive help.
+  --name=NAME  Set name.
+
+...
+
+    my ($stdout, $stderr, $ret, $exit) = capture {
+        $kingpin->parse;
+    };
+    is $stdout, $expected;
+};
+
+subtest 'default5' => sub {
+    require Path::Tiny;
+    local @ARGV;
+    push @ARGV, qw(--help);
+
+    my $kingpin = Getopt::Kingpin->new;
+    $kingpin->terminate(sub {return @_});
+    my $name = $kingpin->flag('input', 'Set input.')->default(Path::Tiny::path('Build.PL'))->file();
+
+    my $expected = sprintf <<'...', basename($0);
+usage: %s [<flags>]
+
+Flags:
+  --help              Show context-sensitive help.
+  --input="Build.PL"  Set input.
+
+...
+
+    my ($stdout, $stderr, $ret, $exit) = capture {
+        $kingpin->parse;
+    };
+    is $stdout, $expected;
+};
+
 subtest 'place holder' => sub {
     local @ARGV;
     push @ARGV, qw(--help);

--- a/t/18_file.t
+++ b/t/18_file.t
@@ -105,5 +105,18 @@ subtest 'file with default' => sub {
     is ref $path->value, "Path::Tiny";
 };
 
+subtest 'file with blessed default' => sub {
+    local @ARGV;
+    require Path::Tiny;
+
+    my $kingpin = Getopt::Kingpin->new();
+    my $path = $kingpin->flag("path", "")->default(Path::Tiny::path("Build.PL"))->file();
+
+    $kingpin->parse;
+
+    is $path, "Build.PL";
+    is ref $path->value, "Path::Tiny";
+};
+
 done_testing;
 


### PR DESCRIPTION
This allows for `$flag->default(sub { ... })` or for the default to be an object overloading `&{}`.

Issue #43 