### PR TITLE
Add Getopt::Kingpin::Type::Enum

### DIFF
--- a/lib/Getopt/Kingpin/Base.pm
+++ b/lib/Getopt/Kingpin/Base.pm
@@ -10,11 +10,14 @@ our $VERSION = "0.10";
 our $types;
 sub AUTOLOAD {
     my $self = shift;
+    my (@args) = @_;
     my $func = our $AUTOLOAD;
     $func =~ s/.*:://;
     my $type = _camelize($func);
 
     $self->_set_types($type);
+
+    $self->_set_options(@args);
 
     $self->type($type);
 
@@ -56,6 +59,13 @@ sub _set_types {
     }
 }
 
+sub _set_options {
+    my $self = shift;
+    my @options = @_;
+
+    $self->{_options} = \@options;
+}
+
 sub _camelize {
     my $c = shift;
     $c =~ s/(^|_)(.)/uc($2)/ge;
@@ -79,6 +89,7 @@ has _envar        => undef;
 has type          => "String";
 has _required     => 0;
 has index         => 0;
+has _options      => sub { [] };
 
 sub short {
     my $self = shift;

--- a/lib/Getopt/Kingpin/Type/Enum.pm
+++ b/lib/Getopt/Kingpin/Type/Enum.pm
@@ -1,0 +1,61 @@
+package Getopt::Kingpin::Type::Enum;
+use 5.008001;
+use strict;
+use warnings;
+use Carp;
+
+our $VERSION = "0.10";
+
+sub set_value {
+    my $self = shift;
+    my ($value) = @_;
+
+    if ((scalar grep {$value eq $_} @{$self->{_options}}) == 0) {
+        printf STDERR "error: '%s' does not exist in Enum-values=(%s), try --help\n", $value, join(", ", @{$self->{_options}});
+        return undef, 1;
+    }
+
+    return $value;
+}
+
+1;
+__END__
+
+=encoding utf-8
+
+=head1 NAME
+
+Getopt::Kingpin::Type::Enum - command line option object
+
+=head1 SYNOPSIS
+
+    use Getopt::Kingpin;
+    my $kingpin = Getopt::Kingpin->new;
+    my $member = $kingpin->flag('member', 'select member name')->Enum('foo', 'bar', 'baz');
+    $kingpin->parse;
+
+    printf "member name : %s\n", $member;
+
+=head1 DESCRIPTION
+
+Getopt::Kingpin::Type::Enum is the type definition for Enum within Getopt::Kingpin.
+
+=head1 METHOD
+
+=head2 set_value($value)
+
+Set the value of $self->value.
+
+=head1 LICENSE
+
+Copyright (C) sago35.
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=head1 AUTHOR
+
+sago35 E<lt>sago35@gmail.comE<gt>
+
+=cut
+

--- a/lib/Getopt/Kingpin/Type/Enum.pm
+++ b/lib/Getopt/Kingpin/Type/Enum.pm
@@ -11,7 +11,7 @@ sub set_value {
     my ($value) = @_;
 
     if ((scalar grep {$value eq $_} @{$self->{_options}}) == 0) {
-        printf STDERR "error: '%s' does not exist in Enum-values=(%s), try --help\n", $value, join(", ", @{$self->{_options}});
+        printf STDERR "error: enum value must be one of %s, got '%s', try --help\n", join(",", @{$self->{_options}}), $value;
         return undef, 1;
     }
 


### PR DESCRIPTION
sample code
```
use strict;
use warnings;

# !Attention! : This is my local repository-path
use lib qw(C:/Users/blues/ehime-iyokan/public/Getopt-Kingpin/lib);

use Getopt::Kingpin;

my $kingpin = Getopt::Kingpin->new;
my $member = $kingpin->flag('member', 'select member name')->Enum('foo', 'bar', 'baz');
$kingpin->parse;

printf "member name : %s\n", $member;
```
output
```
$  perl sample.pl --member foo 
member name : foo
```

output (error)
```
$  perl sample.pl --member fuga
error: 'fuga' does not exist in Enum-values=(foo, bar, baz), try --help
```